### PR TITLE
Add an SMS page for compatible routers in Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ Selected trackers persist across reloads and report `not_home` when the client i
 Controls how often the router is polled for new data. The default is **60 seconds**. Accepted range is 15 to 3600 seconds, in steps of 5.
 
 
+## SMS Panel
+
+SMS-capable routers expose an admin-only sidebar panel at `/cudy-router-sms`.
+
+The **Cudy SMS** panel provides:
+
+- A router selector for multi-router setups
+- Inbox and outbox browsing with full message bodies
+- Reply prefill from a selected message
+- An SMS compose form for sending messages through the router modem
+
+On SMS-capable routers, **Configure Cudy Router** also includes a **Show Cudy SMS in sidebar** option. Turning it off hides the sidebar link while keeping the panel available by direct URL.
+
+The device page still keeps `SMS inbox`, `SMS outbox`, and `SMS unread` as standard count entities. Clicking those entities uses the normal Home Assistant more-info dialog and does not open the SMS browser.
+
+
 ## Services
 
 ### `cudy_router.reboot_router`

--- a/custom_components/cudy_router/__init__.py
+++ b/custom_components/cudy_router/__init__.py
@@ -15,7 +15,11 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
@@ -34,6 +38,7 @@ from .device_info import (
     known_client_devices,
     known_tracker_clients,
 )
+from .frontend import async_refresh_frontend
 from .device_tracking import (
     configured_device_ids,
     configured_tracked_macs,
@@ -45,6 +50,7 @@ from .device_tracking import (
 )
 from .model_names import resolve_model_name
 from .router import CudyRouter
+from .sms import async_send_sms_message, coordinator_supports_sms
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -183,6 +189,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: CudyRouterConfigEntry) -
 
     # Register services
     await _async_setup_services(hass)
+    await async_refresh_frontend(hass)
 
     # Reload entry when options are updated
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -307,9 +314,13 @@ async def _async_setup_services(hass: HomeAssistant) -> None:
         if not coordinator:
             _LOGGER.error("No Cudy Router coordinator found")
             return
+        if not coordinator_supports_sms(coordinator):
+            raise HomeAssistantError("The selected Cudy Router does not support SMS")
         phone = call.data[ATTR_PHONE_NUMBER]
         message = call.data[ATTR_MESSAGE]
-        await hass.async_add_executor_job(coordinator.api.send_sms, phone, message)
+        result = await async_send_sms_message(hass, coordinator, phone, message)
+        if not result["success"]:
+            raise HomeAssistantError(result["message"])
 
     async def handle_send_at_command(call: ServiceCall) -> None:
         """Handle the send AT command service call."""
@@ -361,6 +372,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+        await async_refresh_frontend(hass)
         # Unregister services if no more entries
         if not hass.data[DOMAIN]:
             del hass.data[DOMAIN]

--- a/custom_components/cudy_router/config_flow.py
+++ b/custom_components/cudy_router/config_flow.py
@@ -29,9 +29,11 @@ from .const import (
     MAX_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
     MODULE_DEVICES,
+    MODULE_SMS,
     OPTIONS_AUTO_ADD_CONNECTED_DEVICES,
     OPTIONS_AUTO_ADD_DEVICE_TRACKERS,
     OPTIONS_DEVICELIST,
+    OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR,
     OPTIONS_TRACKED_DEVICE_MACS,
     SECTION_DEVICE_LIST,
     normalize_scan_interval,
@@ -45,6 +47,7 @@ from .device_tracking import (
     next_options_flow_step,
     tracker_picker_options,
 )
+from .features import existing_feature
 from .model_names import resolve_model_name
 from .router import CudyRouter
 
@@ -237,7 +240,7 @@ class CudyRouterOptionsFlowHandler(OptionsFlow):
     def _default_pending_options(self) -> dict[str, Any]:
         """Return options state used to drive the multi-step flow."""
         options = self._config_entry.options
-        return {
+        pending = {
             OPTIONS_AUTO_ADD_CONNECTED_DEVICES: options.get(
                 OPTIONS_AUTO_ADD_CONNECTED_DEVICES,
                 True,
@@ -252,6 +255,22 @@ class CudyRouterOptionsFlowHandler(OptionsFlow):
                 options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
             ),
         }
+        if self._supports_sms():
+            pending[OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR] = options.get(
+                OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR,
+                True,
+            )
+        return pending
+
+    def _supports_sms(self) -> bool:
+        """Return whether this config entry supports SMS-specific options."""
+        return (
+            existing_feature(
+                self._config_entry.data.get(CONF_MODEL, "default"),
+                MODULE_SMS,
+            )
+            is True
+        )
 
     def _pending_options_state(self) -> dict[str, Any]:
         """Return the in-progress options payload."""
@@ -316,6 +335,11 @@ class CudyRouterOptionsFlowHandler(OptionsFlow):
                     options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
                 )
             )
+            if self._supports_sms():
+                self._pending_options[OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR] = user_input.get(
+                    OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR,
+                    options.get(OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR, True),
+                )
 
             next_step = self._next_step()
             if next_step == "manual_devices":
@@ -324,39 +348,50 @@ class CudyRouterOptionsFlowHandler(OptionsFlow):
                 return await self.async_step_trackers()
             return self._async_create_entry_from_pending_options()
 
-        schema = vol.Schema(
-            {
-                vol.Optional(OPTIONS_AUTO_ADD_CONNECTED_DEVICES): selector.BooleanSelector(),
-                vol.Optional(OPTIONS_AUTO_ADD_DEVICE_TRACKERS): selector.BooleanSelector(),
-                vol.Optional(CONF_SCAN_INTERVAL): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        mode=selector.NumberSelectorMode.BOX,
-                        unit_of_measurement="seconds",
-                        min=MIN_SCAN_INTERVAL,
-                        max=MAX_SCAN_INTERVAL,
-                        step=5,
-                    ),
+        schema_fields: dict[Any, Any] = {
+            vol.Optional(OPTIONS_AUTO_ADD_CONNECTED_DEVICES): selector.BooleanSelector(),
+            vol.Optional(OPTIONS_AUTO_ADD_DEVICE_TRACKERS): selector.BooleanSelector(),
+            vol.Optional(CONF_SCAN_INTERVAL): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    mode=selector.NumberSelectorMode.BOX,
+                    unit_of_measurement="seconds",
+                    min=MIN_SCAN_INTERVAL,
+                    max=MAX_SCAN_INTERVAL,
+                    step=5,
                 ),
-            }
-        )
+            ),
+        }
+        if self._supports_sms():
+            schema_fields[vol.Optional(OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR)] = (
+                selector.BooleanSelector()
+            )
+
+        schema = vol.Schema(schema_fields)
+
+        suggested_values = {
+            OPTIONS_AUTO_ADD_CONNECTED_DEVICES: options.get(
+                OPTIONS_AUTO_ADD_CONNECTED_DEVICES,
+                True,
+            ),
+            OPTIONS_AUTO_ADD_DEVICE_TRACKERS: options.get(
+                OPTIONS_AUTO_ADD_DEVICE_TRACKERS,
+                False,
+            ),
+            CONF_SCAN_INTERVAL: normalize_scan_interval(
+                options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+            ),
+        }
+        if self._supports_sms():
+            suggested_values[OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR] = options.get(
+                OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR,
+                True,
+            )
 
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(
                 schema,
-                {
-                    OPTIONS_AUTO_ADD_CONNECTED_DEVICES: options.get(
-                        OPTIONS_AUTO_ADD_CONNECTED_DEVICES,
-                        True,
-                    ),
-                    OPTIONS_AUTO_ADD_DEVICE_TRACKERS: options.get(
-                        OPTIONS_AUTO_ADD_DEVICE_TRACKERS,
-                        False,
-                    ),
-                    CONF_SCAN_INTERVAL: normalize_scan_interval(
-                        options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-                    ),
-                },
+                suggested_values,
             ),
         )
 

--- a/custom_components/cudy_router/const.py
+++ b/custom_components/cudy_router/const.py
@@ -32,6 +32,7 @@ OPTIONS_DEVICELIST = "device_list"
 OPTIONS_AUTO_ADD_CONNECTED_DEVICES = "auto_add_connected_devices"
 OPTIONS_AUTO_ADD_DEVICE_TRACKERS = "auto_add_device_trackers"
 OPTIONS_TRACKED_DEVICE_MACS = "tracked_device_macs"
+OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR = "show_sms_panel_in_sidebar"
 
 # Mesh device attributes
 ATTR_MESH_MAC = "mac_address"

--- a/custom_components/cudy_router/frontend.py
+++ b/custom_components/cudy_router/frontend.py
@@ -1,0 +1,211 @@
+"""Frontend panel and websocket wiring for Cudy SMS."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components import frontend as ha_frontend
+from homeassistant.components import websocket_api
+from homeassistant.components.http import StaticPathConfig
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+from .sms import (
+    SMS_PANEL_COMPONENT_NAME,
+    SMS_PANEL_STATIC_FILE,
+    SMS_PANEL_STATIC_URL,
+    SMS_PANEL_URL_PATH,
+    async_fetch_sms_data,
+    async_send_sms_message,
+    coordinator_shows_sms_panel_in_sidebar,
+    coordinator_supports_sms,
+    sms_capable_coordinators,
+    sms_entry_payload,
+)
+
+_RUNTIME_KEY = f"{DOMAIN}_frontend"
+
+
+def _runtime_state(hass: HomeAssistant) -> dict[str, bool]:
+    """Return mutable runtime state for frontend helpers."""
+    return hass.data.setdefault(
+        _RUNTIME_KEY,
+        {
+            "panel_registered": False,
+            "static_registered": False,
+            "websocket_registered": False,
+        },
+    )
+
+
+def _coordinator_for_entry_id(hass: HomeAssistant, entry_id: str) -> Any | None:
+    """Return the loaded coordinator for an entry id."""
+    return hass.data.get(DOMAIN, {}).get(entry_id)
+
+
+async def _async_register_static_path(hass: HomeAssistant) -> None:
+    """Register the panel JavaScript bundle."""
+    runtime = _runtime_state(hass)
+    if runtime["static_registered"]:
+        return
+
+    panel_path = Path(__file__).parent / SMS_PANEL_STATIC_FILE
+    await hass.http.async_register_static_paths(
+        [StaticPathConfig(SMS_PANEL_STATIC_URL, str(panel_path), False)]
+    )
+    runtime["static_registered"] = True
+
+
+def _register_panel(hass: HomeAssistant, *, show_in_sidebar: bool) -> None:
+    """Register or update the sidebar panel."""
+    runtime = _runtime_state(hass)
+    panel_path = Path(__file__).parent / SMS_PANEL_STATIC_FILE
+    panel_version = panel_path.stat().st_mtime_ns
+
+    ha_frontend.async_register_built_in_panel(
+        hass,
+        component_name="custom",
+        sidebar_title="Cudy SMS",
+        sidebar_icon="mdi:message-text",
+        frontend_url_path=SMS_PANEL_URL_PATH,
+        config={
+            "_panel_custom": {
+                "name": SMS_PANEL_COMPONENT_NAME,
+                "embed_iframe": False,
+                "trust_external": False,
+                "module_url": f"{SMS_PANEL_STATIC_URL}?v={panel_version}",
+            }
+        },
+        require_admin=True,
+        show_in_sidebar=show_in_sidebar,
+        update=runtime["panel_registered"],
+    )
+    runtime["panel_registered"] = True
+
+
+def _remove_panel(hass: HomeAssistant) -> None:
+    """Remove the sidebar panel if it is no longer needed."""
+    runtime = _runtime_state(hass)
+    if not runtime["panel_registered"]:
+        return
+
+    ha_frontend.async_remove_panel(hass, SMS_PANEL_URL_PATH, warn_if_unknown=False)
+    runtime["panel_registered"] = False
+
+
+def _register_websocket_commands(hass: HomeAssistant) -> None:
+    """Register websocket handlers once."""
+    runtime = _runtime_state(hass)
+    if runtime["websocket_registered"]:
+        return
+
+    websocket_api.async_register_command(hass, websocket_list_sms_entries)
+    websocket_api.async_register_command(hass, websocket_get_sms_messages)
+    websocket_api.async_register_command(hass, websocket_send_sms)
+    runtime["websocket_registered"] = True
+
+
+async def async_refresh_frontend(hass: HomeAssistant) -> None:
+    """Ensure the SMS panel matches the currently loaded entries."""
+    coordinators = sms_capable_coordinators(hass)
+    if coordinators:
+        await _async_register_static_path(hass)
+        _register_websocket_commands(hass)
+        _register_panel(
+            hass,
+            show_in_sidebar=any(
+                coordinator_shows_sms_panel_in_sidebar(coordinator)
+                for coordinator in coordinators
+            ),
+        )
+        return
+
+    _remove_panel(hass)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "cudy_router/sms/list_entries",
+    }
+)
+@websocket_api.require_admin
+def websocket_list_sms_entries(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """List SMS-capable Cudy entries."""
+    entries = [sms_entry_payload(coordinator) for coordinator in sms_capable_coordinators(hass)]
+    connection.send_result(msg["id"], {"entries": entries})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "cudy_router/sms/get_messages",
+        vol.Required("entry_id"): str,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def websocket_get_sms_messages(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return the latest SMS messages for one router."""
+    coordinator = _coordinator_for_entry_id(hass, msg["entry_id"])
+    if coordinator is None:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, "Unknown Cudy Router entry.")
+        return
+    if not coordinator_supports_sms(coordinator):
+        connection.send_error(
+            msg["id"],
+            websocket_api.ERR_NOT_SUPPORTED,
+            "The selected router does not support SMS.",
+        )
+        return
+
+    connection.send_result(msg["id"], await async_fetch_sms_data(hass, coordinator))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "cudy_router/sms/send",
+        vol.Required("entry_id"): str,
+        vol.Required("phone_number"): str,
+        vol.Required("message"): str,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def websocket_send_sms(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Send an SMS via the selected router."""
+    coordinator = _coordinator_for_entry_id(hass, msg["entry_id"])
+    if coordinator is None:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, "Unknown Cudy Router entry.")
+        return
+    if not coordinator_supports_sms(coordinator):
+        connection.send_error(
+            msg["id"],
+            websocket_api.ERR_NOT_SUPPORTED,
+            "The selected router does not support SMS.",
+        )
+        return
+
+    result = await async_send_sms_message(
+        hass,
+        coordinator,
+        msg["phone_number"],
+        msg["message"],
+    )
+    if not result["success"]:
+        raise HomeAssistantError(result["message"])
+
+    connection.send_result(msg["id"], result)

--- a/custom_components/cudy_router/frontend/cudy-router-sms-panel.js
+++ b/custom_components/cudy_router/frontend/cudy-router-sms-panel.js
@@ -1,0 +1,1109 @@
+class CudyRouterSmsPanel extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._hass = null;
+    this._panel = null;
+    this._route = null;
+    this._narrow = false;
+    this._entries = [];
+    this._selectedEntryId = "";
+    this._selectedTab = "inbox";
+    this._selectedMessageKey = "";
+    this._data = null;
+    this._entriesLoading = false;
+    this._messagesLoading = false;
+    this._sendPending = false;
+    this._error = "";
+    this._notice = "";
+    this._composePhone = "";
+    this._composeMessage = "";
+    this._bootstrapped = false;
+  }
+
+  set hass(hass) {
+    const firstLoad = !this._hass;
+    this._hass = hass;
+    if (firstLoad && !this._bootstrapped) {
+      this._bootstrapped = true;
+      this._loadEntries();
+    }
+    this._render();
+  }
+
+  set panel(panel) {
+    this._panel = panel;
+    this._render();
+  }
+
+  set route(route) {
+    this._route = route;
+    this._render();
+  }
+
+  set narrow(narrow) {
+    this._narrow = Boolean(narrow);
+    this._render();
+  }
+
+  async _callApi(message) {
+    if (!this._hass) {
+      throw new Error("Home Assistant connection is not ready.");
+    }
+    return this._hass.connection.sendMessagePromise(message);
+  }
+
+  async _loadEntries(preserveSelection = true) {
+    this._entriesLoading = true;
+    this._error = "";
+    this._render();
+    try {
+      const result = await this._callApi({
+        type: "cudy_router/sms/list_entries",
+      });
+      this._entries = Array.isArray(result.entries) ? result.entries : [];
+
+      if (!this._entries.length) {
+        this._selectedEntryId = "";
+        this._data = null;
+        this._selectedMessageKey = "";
+        return;
+      }
+
+      const stillValid =
+        preserveSelection &&
+        this._selectedEntryId &&
+        this._entries.some((entry) => entry.entry_id === this._selectedEntryId);
+
+      if (!stillValid) {
+        this._selectedEntryId = this._entries[0].entry_id;
+      }
+
+      await this._loadMessages();
+    } catch (err) {
+      this._error = err?.message || "Failed to load SMS-capable routers.";
+    } finally {
+      this._entriesLoading = false;
+      this._render();
+    }
+  }
+
+  async _loadMessages() {
+    if (!this._selectedEntryId) {
+      this._data = null;
+      this._selectedMessageKey = "";
+      this._render();
+      return;
+    }
+
+    this._messagesLoading = true;
+    this._error = "";
+    this._notice = "";
+    this._render();
+    try {
+      this._data = await this._callApi({
+        type: "cudy_router/sms/get_messages",
+        entry_id: this._selectedEntryId,
+      });
+      this._syncSelectedMessage();
+    } catch (err) {
+      this._error = err?.message || "Failed to load SMS messages.";
+      this._data = null;
+      this._selectedMessageKey = "";
+    } finally {
+      this._messagesLoading = false;
+      this._render();
+    }
+  }
+
+  _mailbox(folder) {
+    return this._data?.mailboxes?.[folder] || { available: false, messages: [] };
+  }
+
+  _messageKey(message) {
+    return message.cfg || `${message.folder || this._selectedTab}:${message.index || message.timestamp || ""}`;
+  }
+
+  _messagesForSelectedTab() {
+    return this._mailbox(this._selectedTab).messages || [];
+  }
+
+  _syncSelectedMessage() {
+    const messages = this._messagesForSelectedTab();
+    if (!messages.length) {
+      this._selectedMessageKey = "";
+      return;
+    }
+
+    const existing = messages.find(
+      (message) => this._messageKey(message) === this._selectedMessageKey,
+    );
+    if (!existing) {
+      this._selectedMessageKey = this._messageKey(messages[0]);
+    }
+  }
+
+  _selectedMessage() {
+    return this._messagesForSelectedTab().find(
+      (message) => this._messageKey(message) === this._selectedMessageKey,
+    ) || null;
+  }
+
+  async _sendSms() {
+    if (!this._selectedEntryId || !this._composePhone.trim() || !this._composeMessage.trim()) {
+      this._error = "Phone number and message are required.";
+      this._notice = "";
+      this._render();
+      return;
+    }
+
+    this._sendPending = true;
+    this._error = "";
+    this._notice = "";
+    this._render();
+    try {
+      const result = await this._callApi({
+        type: "cudy_router/sms/send",
+        entry_id: this._selectedEntryId,
+        phone_number: this._composePhone.trim(),
+        message: this._composeMessage,
+      });
+      this._notice = result.message || "SMS sent.";
+      this._composeMessage = "";
+      await this._loadMessages();
+      await this._loadEntries(true);
+    } catch (err) {
+      this._error = err?.message || "Failed to send SMS.";
+    } finally {
+      this._sendPending = false;
+      this._render();
+    }
+  }
+
+  _setSelectedTab(tab) {
+    this._selectedTab = tab;
+    this._selectedMessageKey = "";
+    this._syncSelectedMessage();
+    this._render();
+  }
+
+  _replyToSelectedMessage() {
+    const message = this._selectedMessage();
+    if (!message) {
+      return;
+    }
+    this._composePhone = message.phone || "";
+    this._notice = "Recipient copied into the compose form.";
+    this._error = "";
+    this._render();
+    const textarea = this.shadowRoot.querySelector("#compose-message");
+    if (textarea) {
+      textarea.focus();
+    }
+  }
+
+  _escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
+  _renderMessageList() {
+    const mailbox = this._mailbox(this._selectedTab);
+    if (!mailbox.available) {
+      return `<div class="empty">The router did not return the ${this._selectedTab} mailbox details.</div>`;
+    }
+
+    if (!mailbox.messages.length) {
+      return `<div class="empty">No ${this._selectedTab} messages on this router.</div>`;
+    }
+
+    return mailbox.messages
+      .map((message) => {
+        const key = this._messageKey(message);
+        const activeClass = key === this._selectedMessageKey ? "message-item active" : "message-item";
+        const status = this._selectedTab === "inbox"
+          ? `<span class="chip ${message.read ? "muted" : "unread"}">${message.read ? "Read" : "Unread"}</span>`
+          : `<span class="chip muted">Sent</span>`;
+        return `
+          <button class="${activeClass}" data-message-key="${this._escapeHtml(key)}">
+            <div class="message-row">
+              <div class="message-phone">
+                <strong>${this._escapeHtml(message.phone || "Unknown number")}</strong>
+              </div>
+              ${status}
+            </div>
+            <div class="message-preview">${this._escapeHtml(message.preview || message.text || "No preview available.")}</div>
+            <div class="message-meta">${this._escapeHtml(message.timestamp || "Unknown time")}</div>
+          </button>
+        `;
+      })
+      .join("");
+  }
+
+  _renderMessageDetail() {
+    const message = this._selectedMessage();
+    if (!message) {
+      return `<div class="empty detail-empty">Select a message to read its full contents.</div>`;
+    }
+
+    const body = this._escapeHtml(message.text || "No message body available.").replaceAll("\n", "<br>");
+    const statusLine =
+      this._selectedTab === "inbox"
+        ? `<div class="detail-meta"><span>Status</span><strong>${message.read ? "Read" : "Unread"}</strong></div>`
+        : "";
+
+    return `
+      <div class="detail-card">
+        <div class="detail-header">
+          <div>
+            <div class="detail-label">${this._selectedTab === "inbox" ? "From" : "To"}</div>
+            <h2>${this._escapeHtml(message.phone || "Unknown number")}</h2>
+          </div>
+          <button id="reply-button" class="secondary">Reply</button>
+        </div>
+        <div class="detail-meta"><span>Time</span><strong>${this._escapeHtml(message.timestamp || "Unknown")}</strong></div>
+        ${statusLine}
+        <div class="detail-body">${body}</div>
+      </div>
+    `;
+  }
+
+  _render() {
+    const selectedEntry = this._entries.find((entry) => entry.entry_id === this._selectedEntryId) || null;
+    const counts = this._data?.counts || selectedEntry?.counts || { inbox: 0, outbox: 0, unread: 0 };
+    const loading = this._entriesLoading || this._messagesLoading;
+    const selectedMessage = this._selectedMessage();
+    const darkMode = Boolean(this._hass?.themes?.darkMode);
+    const theme = darkMode
+      ? {
+          pageBackground: "#11161c",
+          cardBackground: "#1b212c",
+          subtleBackground: "#151b24",
+          surfaceHover: "#232c39",
+          text: "#e8edf5",
+          muted: "#a9b4c6",
+          divider: "rgba(232, 237, 245, 0.14)",
+          border: "rgba(232, 237, 245, 0.16)",
+          borderStrong: "rgba(232, 237, 245, 0.24)",
+          cardBorder: "rgba(232, 237, 245, 0.12)",
+          controlBackground: "#121821",
+          controlBorder: "rgba(232, 237, 245, 0.22)",
+          controlOutline: "rgba(232, 237, 245, 0.14)",
+          shadow: "0 18px 36px rgba(0, 0, 0, 0.34), 0 4px 12px rgba(0, 0, 0, 0.28)",
+          success: "#81c784",
+          warning: "#ffca28",
+          error: "#ef9a9a",
+          accent: "#03a9f4",
+        }
+      : {
+          pageBackground: "#f6f8fc",
+          cardBackground: "#ffffff",
+          subtleBackground: "#f3f5f9",
+          surfaceHover: "#eef4fc",
+          text: "#1f2937",
+          muted: "#5f6b7a",
+          divider: "rgba(31, 41, 55, 0.14)",
+          border: "rgba(31, 41, 55, 0.14)",
+          borderStrong: "rgba(31, 41, 55, 0.22)",
+          cardBorder: "rgba(31, 41, 55, 0.10)",
+          controlBackground: "#ffffff",
+          controlBorder: "rgba(31, 41, 55, 0.18)",
+          controlOutline: "rgba(31, 41, 55, 0.12)",
+          shadow: "0 12px 32px rgba(15, 23, 42, 0.08), 0 2px 8px rgba(15, 23, 42, 0.05)",
+          success: "#2e7d32",
+          warning: "#b26a00",
+          error: "#d14343",
+          accent: "#009ac7",
+        };
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          --sms-panel-font-family: var(
+            --paper-font-common-base_-_font-family,
+            "Roboto",
+            "Noto Sans",
+            sans-serif
+          );
+          --sms-panel-page-background: var(--primary-background-color, ${theme.pageBackground});
+          --sms-panel-card-background: var(
+            --ha-card-background,
+            var(--card-background-color, ${theme.cardBackground})
+          );
+          --sms-panel-subtle-background: var(--secondary-background-color, ${theme.subtleBackground});
+          --sms-panel-text: var(--primary-text-color, ${theme.text});
+          --sms-panel-muted: var(--secondary-text-color, ${theme.muted});
+          --sms-panel-divider: var(--divider-color, ${theme.divider});
+          --sms-panel-border: ${theme.border};
+          --sms-panel-border-strong: ${theme.borderStrong};
+          --sms-panel-card-border: ${theme.cardBorder};
+          --sms-panel-control-background: ${theme.controlBackground};
+          --sms-panel-control-border: ${theme.controlBorder};
+          --sms-panel-control-outline: ${theme.controlOutline};
+          --sms-panel-surface: var(--sms-panel-card-background);
+          --sms-panel-surface-alt: var(--sms-panel-subtle-background);
+          --sms-panel-surface-hover: ${theme.surfaceHover};
+          --sms-panel-accent: var(--primary-color, ${theme.accent});
+          --sms-panel-accent-contrast: #fff;
+          --sms-panel-accent-soft: color-mix(in srgb, var(--sms-panel-accent) 16%, transparent);
+          --sms-panel-accent-bright: color-mix(in srgb, var(--sms-panel-accent) 84%, white 16%);
+          --sms-panel-accent-deep: color-mix(in srgb, var(--sms-panel-accent) 72%, black 28%);
+          --sms-panel-shadow: ${theme.shadow};
+          --sms-panel-success: ${theme.success};
+          --sms-panel-warning: ${theme.warning};
+          --sms-panel-error: ${theme.error};
+          --sms-panel-radius: var(--ha-card-border-radius, 16px);
+          display: block;
+          min-height: 100%;
+          box-sizing: border-box;
+          background:
+            radial-gradient(circle at top left, var(--sms-panel-accent-soft), transparent 28%),
+            var(--sms-panel-page-background);
+          color: var(--sms-panel-text);
+          padding: 24px;
+          font-family: var(--sms-panel-font-family);
+          font-size: 16px;
+          line-height: 1.5;
+          -webkit-font-smoothing: antialiased;
+          text-rendering: optimizeLegibility;
+        }
+
+        * {
+          box-sizing: border-box;
+          font-family: inherit;
+        }
+
+        .shell {
+          display: grid;
+          gap: 18px;
+          max-width: 1480px;
+          margin: 0 auto;
+        }
+
+        .hero,
+        .list-pane,
+        .detail-pane,
+        .composer {
+          background: var(--sms-panel-card-background);
+          border: 1px solid var(--sms-panel-card-border);
+          box-shadow:
+            0 0 0 1px color-mix(in srgb, var(--sms-panel-card-border) 72%, transparent),
+            var(--sms-panel-shadow);
+          border-radius: var(--sms-panel-radius);
+        }
+
+        .hero {
+          padding: 20px;
+          display: grid;
+          gap: 18px;
+        }
+
+        .hero-top {
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: space-between;
+          gap: 12px;
+          align-items: start;
+        }
+
+        .hero-copy {
+          display: grid;
+          gap: 4px;
+          max-width: 760px;
+        }
+
+        .hero-grid {
+          display: grid;
+          grid-template-columns: minmax(260px, 360px) minmax(0, 1fr);
+          gap: 16px;
+          align-items: end;
+        }
+
+        .pane-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: start;
+          gap: 12px;
+        }
+
+        .pane-title {
+          display: grid;
+          gap: 4px;
+        }
+
+        .pane-kicker {
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: var(--sms-panel-muted);
+          font-size: 0.73rem;
+          font-weight: 700;
+        }
+
+        .eyebrow {
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: var(--sms-panel-muted);
+          font-size: 0.75rem;
+          font-weight: 600;
+        }
+
+        h1 {
+          margin: 4px 0 0;
+          font-size: clamp(1.55rem, 2vw, 2.15rem);
+          line-height: 1.15;
+          font-weight: 700;
+          letter-spacing: -0.02em;
+        }
+
+        h2 {
+          margin: 0;
+          font-size: 1.45rem;
+          line-height: 1.2;
+          font-weight: 700;
+          letter-spacing: -0.01em;
+        }
+
+        label {
+          display: grid;
+          gap: 6px;
+        }
+
+        .control-shell {
+          display: flex;
+          align-items: center;
+          min-height: 50px;
+          border: 1px solid var(--sms-panel-control-border);
+          border-radius: 12px;
+          background: var(--sms-panel-control-background);
+          box-shadow:
+            inset 0 1px 0 color-mix(in srgb, var(--sms-panel-text) 4%, transparent),
+            0 0 0 1px var(--sms-panel-control-outline),
+            0 1px 2px color-mix(in srgb, black 12%, transparent);
+          transition:
+            border-color 120ms ease,
+            box-shadow 120ms ease,
+            background 120ms ease,
+            transform 120ms ease;
+        }
+
+        .control-shell:focus-within {
+          border-color: var(--sms-panel-accent);
+          background: color-mix(in srgb, var(--sms-panel-control-background) 86%, var(--sms-panel-accent-soft) 14%);
+          box-shadow:
+            inset 0 1px 0 color-mix(in srgb, var(--sms-panel-accent) 12%, transparent),
+            0 0 0 1px var(--sms-panel-control-outline),
+            0 0 0 3px color-mix(in srgb, var(--sms-panel-accent) 30%, transparent);
+        }
+
+        .control-shell.multiline {
+          align-items: stretch;
+          min-height: 170px;
+        }
+
+        .field-label {
+          color: var(--sms-panel-muted);
+          font-size: 0.88rem;
+          font-weight: 600;
+        }
+
+        .subtle {
+          color: var(--sms-panel-muted);
+          font-size: 0.95rem;
+          line-height: 1.45;
+        }
+
+        select,
+        textarea,
+        input,
+        button {
+          font: inherit;
+          color: var(--sms-panel-text);
+        }
+
+        select,
+        textarea,
+        input {
+          width: 100%;
+          border: 0;
+          border-radius: 12px;
+          background: transparent;
+          color: inherit;
+          padding: 12px 14px;
+          outline: none;
+          box-shadow: none;
+          transition: background 120ms ease;
+        }
+
+        select option {
+          background: var(--sms-panel-surface);
+          color: var(--sms-panel-text);
+        }
+
+        select {
+          appearance: none;
+          background-image:
+            linear-gradient(45deg, transparent 50%, var(--sms-panel-muted) 50%),
+            linear-gradient(135deg, var(--sms-panel-muted) 50%, transparent 50%);
+          background-position:
+            calc(100% - 20px) calc(50% - 2px),
+            calc(100% - 14px) calc(50% - 2px);
+          background-size: 6px 6px, 6px 6px;
+          background-repeat: no-repeat;
+          padding-right: 34px;
+        }
+
+        textarea::placeholder,
+        input::placeholder {
+          color: var(--sms-panel-muted);
+          opacity: 1;
+        }
+
+        select:focus,
+        textarea:focus,
+        input:focus {
+          box-shadow: none;
+        }
+
+        textarea {
+          min-height: 160px;
+          resize: vertical;
+        }
+
+        button {
+          appearance: none;
+          border: 1px solid var(--sms-panel-control-border);
+          border-radius: 999px;
+          padding: 10px 18px;
+          cursor: pointer;
+          transition:
+            transform 120ms ease,
+            opacity 120ms ease,
+            background 120ms ease,
+            border-color 120ms ease,
+            box-shadow 120ms ease;
+          min-height: 42px;
+        }
+
+        button:hover {
+          transform: translateY(-1px);
+        }
+
+        button:disabled {
+          cursor: default;
+          opacity: 0.55;
+          transform: none;
+        }
+
+        .primary {
+          background: linear-gradient(
+            135deg,
+            var(--sms-panel-accent-bright),
+            var(--sms-panel-accent-deep)
+          );
+          color: var(--sms-panel-accent-contrast);
+          font-weight: 600;
+          border-color: color-mix(in srgb, var(--sms-panel-accent-deep) 78%, black 22%);
+          text-shadow: 0 1px 0 rgba(0, 0, 0, 0.28);
+          box-shadow:
+            0 0 0 1px color-mix(in srgb, var(--sms-panel-accent) 42%, transparent),
+            0 10px 22px color-mix(in srgb, var(--sms-panel-accent) 28%, transparent);
+        }
+
+        .primary:hover {
+          box-shadow:
+            0 0 0 1px color-mix(in srgb, var(--sms-panel-accent) 46%, transparent),
+            0 14px 28px color-mix(in srgb, var(--sms-panel-accent) 32%, transparent);
+        }
+
+        .primary:disabled {
+          background: color-mix(in srgb, var(--sms-panel-accent) 28%, var(--sms-panel-surface) 72%);
+          color: color-mix(in srgb, var(--sms-panel-text) 58%, transparent);
+          border-color: var(--sms-panel-border);
+          box-shadow: none;
+        }
+
+        .secondary,
+        .tab {
+          color: var(--sms-panel-text);
+          border: 1px solid var(--sms-panel-control-border);
+          font-weight: 600;
+        }
+
+        .secondary {
+          background: linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--sms-panel-control-background) 92%, white 8%),
+            color-mix(in srgb, var(--sms-panel-subtle-background) 88%, black 12%)
+          );
+          color: var(--sms-panel-text);
+          border-color: var(--sms-panel-control-border);
+          box-shadow:
+            inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+            0 0 0 1px var(--sms-panel-control-outline),
+            0 2px 5px color-mix(in srgb, black 14%, transparent);
+          min-width: 104px;
+          border-radius: 12px;
+        }
+
+        .toolbar-button {
+          min-width: 116px;
+          min-height: 44px;
+          padding-inline: 18px;
+          font-weight: 700;
+        }
+
+        .tab {
+          background: var(--sms-panel-subtle-background);
+          box-shadow: 0 0 0 1px var(--sms-panel-control-outline);
+        }
+
+        .secondary.active,
+        .tab.active {
+          background: color-mix(in srgb, var(--sms-panel-accent) 18%, var(--sms-panel-surface-alt) 82%);
+          border-color: var(--sms-panel-accent);
+          color: var(--sms-panel-text);
+        }
+
+        .secondary:hover,
+        .tab:hover,
+        .message-item:hover {
+          background: var(--sms-panel-surface-hover);
+        }
+
+        .stats {
+          display: grid;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: 12px;
+        }
+
+        .stat {
+          padding: 16px;
+          border-radius: 14px;
+          background: var(--sms-panel-subtle-background);
+          border: 1px solid var(--sms-panel-card-border);
+          box-shadow: inset 0 1px 0 color-mix(in srgb, white 6%, transparent);
+        }
+
+        .stat-label {
+          color: var(--sms-panel-muted);
+          font-size: 0.85rem;
+          margin-bottom: 6px;
+        }
+
+        .stat-value {
+          font-size: 1.7rem;
+          font-weight: 700;
+        }
+
+        .banner {
+          padding: 12px 14px;
+          border-radius: 12px;
+          font-size: 0.95rem;
+        }
+
+        .banner.error {
+          background: color-mix(in srgb, var(--sms-panel-error) 14%, transparent);
+          border: 1px solid color-mix(in srgb, var(--sms-panel-error) 48%, transparent);
+        }
+
+        .banner.notice {
+          background: color-mix(in srgb, var(--sms-panel-success) 14%, transparent);
+          border: 1px solid color-mix(in srgb, var(--sms-panel-success) 48%, transparent);
+        }
+
+        .workspace {
+          display: grid;
+          grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+          gap: 18px;
+          align-items: start;
+        }
+
+        .list-pane,
+        .detail-pane {
+          padding: 18px;
+          display: grid;
+          gap: 14px;
+          min-height: 520px;
+        }
+
+        .list-pane {
+          background: var(--sms-panel-subtle-background);
+          align-content: start;
+        }
+
+        .detail-pane {
+          background: color-mix(in srgb, var(--sms-panel-card-background) 82%, var(--sms-panel-subtle-background) 18%);
+        }
+
+        .tabs {
+          display: flex;
+          gap: 10px;
+        }
+
+        .list-body {
+          display: grid;
+          gap: 14px;
+          align-content: start;
+          align-items: start;
+          min-height: 0;
+        }
+
+        .messages {
+          display: grid;
+          gap: 10px;
+          align-content: start;
+          align-items: start;
+          max-height: 560px;
+          overflow: auto;
+          padding-right: 4px;
+          min-height: 0;
+        }
+
+        .message-item {
+          width: 100%;
+          text-align: left;
+          padding: 11px 12px;
+          border-radius: 14px;
+          background: var(--sms-panel-card-background);
+          border: 1px solid var(--sms-panel-control-border);
+          box-shadow:
+            inset 0 1px 0 color-mix(in srgb, white 6%, transparent),
+            0 0 0 1px var(--sms-panel-control-outline),
+            0 1px 2px color-mix(in srgb, black 10%, transparent);
+        }
+
+        .message-item.active {
+          background: color-mix(in srgb, var(--sms-panel-accent-soft) 70%, var(--sms-panel-card-background) 30%);
+          border-color: var(--sms-panel-accent);
+          box-shadow:
+            inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+            0 0 0 1px var(--sms-panel-accent),
+            0 0 0 3px color-mix(in srgb, var(--sms-panel-accent) 18%, transparent);
+        }
+
+        .message-row {
+          display: flex;
+          justify-content: space-between;
+          gap: 12px;
+          align-items: start;
+          margin-bottom: 5px;
+        }
+
+        .message-phone {
+          display: grid;
+          gap: 2px;
+        }
+
+        .message-phone strong {
+          font-size: 0.98rem;
+          line-height: 1.25;
+        }
+
+        .message-preview,
+        .message-meta,
+        .detail-label {
+          color: var(--sms-panel-muted);
+        }
+
+        .message-preview {
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+          line-height: 1.32;
+        }
+
+        .message-meta {
+          margin-top: 5px;
+          font-size: 0.85rem;
+        }
+
+        .chip {
+          border-radius: 999px;
+          padding: 4px 10px;
+          font-size: 0.75rem;
+          letter-spacing: 0.03em;
+          border: 1px solid var(--sms-panel-border);
+          font-weight: 600;
+        }
+
+        .chip.unread {
+          background: color-mix(in srgb, var(--sms-panel-warning) 20%, transparent);
+        }
+
+        .chip.muted {
+          background: transparent;
+        }
+
+        .detail-card {
+          display: grid;
+          gap: 14px;
+          align-content: start;
+        }
+
+        .detail-header {
+          display: flex;
+          justify-content: space-between;
+          gap: 12px;
+          align-items: start;
+        }
+
+        .detail-header h2 {
+          margin: 4px 0 0;
+          font-size: 1.5rem;
+          line-height: 1.15;
+        }
+
+        .detail-meta {
+          display: flex;
+          justify-content: space-between;
+          gap: 12px;
+          padding: 12px 14px;
+          border-radius: 12px;
+          background: var(--sms-panel-subtle-background);
+          border: 1px solid var(--sms-panel-card-border);
+        }
+
+        .detail-meta span {
+          color: var(--sms-panel-muted);
+        }
+
+        .detail-body {
+          padding: 18px;
+          border-radius: 14px;
+          background: var(--sms-panel-subtle-background);
+          border: 1px solid var(--sms-panel-card-border);
+          line-height: 1.6;
+          min-height: 210px;
+          white-space: normal;
+          overflow-wrap: anywhere;
+        }
+
+        .composer {
+          padding: 20px;
+          display: grid;
+          gap: 18px;
+        }
+
+        .composer-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: 14px;
+        }
+
+        .phone-field {
+          max-width: 340px;
+        }
+
+        .message-field textarea {
+          min-height: 160px;
+        }
+
+        .composer-actions {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          gap: 14px;
+          padding-top: 4px;
+          border-top: 1px solid color-mix(in srgb, var(--sms-panel-border) 70%, transparent);
+        }
+
+        .empty {
+          border: 1px dashed var(--sms-panel-control-outline);
+          border-radius: 14px;
+          padding: 20px;
+          color: var(--sms-panel-muted);
+          background: var(--sms-panel-subtle-background);
+        }
+
+        .detail-empty {
+          min-height: 220px;
+          display: grid;
+          place-items: center;
+        }
+
+        .loading {
+          color: var(--sms-panel-muted);
+          font-size: 0.95rem;
+        }
+
+        @media (max-width: 980px) {
+          :host {
+            padding: 16px;
+          }
+
+          .hero-grid,
+          .workspace,
+          .composer-grid {
+            grid-template-columns: 1fr;
+          }
+
+          .composer-actions {
+            flex-direction: column;
+            align-items: stretch;
+          }
+
+          .stats {
+            grid-template-columns: 1fr;
+          }
+        }
+      </style>
+      <div class="shell">
+        <section class="hero">
+          <div class="hero-top">
+            <div class="hero-copy">
+              <div class="eyebrow">Cudy Router SMS</div>
+              <h1>Inbox, outbox, and send tools in one place</h1>
+              <div class="subtle">Device-page entities stay count-only. Use this panel for message bodies and sending.</div>
+            </div>
+            <button id="refresh-button" class="secondary toolbar-button" ${loading ? "disabled" : ""}>Refresh</button>
+          </div>
+          ${this._error ? `<div class="banner error">${this._escapeHtml(this._error)}</div>` : ""}
+          ${this._notice ? `<div class="banner notice">${this._escapeHtml(this._notice)}</div>` : ""}
+          <div class="hero-grid">
+            <label>
+              <div class="field-label">Router</div>
+              <div class="control-shell">
+                <select id="entry-select" ${this._entriesLoading || !this._entries.length ? "disabled" : ""}>
+                  ${this._entries.length
+                    ? this._entries
+                        .map(
+                          (entry) => `
+                            <option value="${this._escapeHtml(entry.entry_id)}" ${entry.entry_id === this._selectedEntryId ? "selected" : ""}>
+                              ${this._escapeHtml(entry.title)}${entry.model ? ` (${this._escapeHtml(entry.model)})` : ""}
+                            </option>
+                          `,
+                        )
+                        .join("")
+                    : `<option value="">No SMS-capable routers available</option>`}
+                </select>
+              </div>
+            </label>
+            <div class="stats">
+              <div class="stat">
+                <div class="stat-label">Inbox</div>
+                <div class="stat-value">${this._escapeHtml(counts.inbox)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Outbox</div>
+                <div class="stat-value">${this._escapeHtml(counts.outbox)}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">Unread</div>
+                <div class="stat-value">${this._escapeHtml(counts.unread)}</div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        ${
+          !this._entries.length
+            ? `<section class="workspace"><div class="detail-pane"><div class="empty detail-empty">No SMS-capable Cudy Router entries are currently loaded.</div></div></section>`
+            : `
+              <section class="workspace">
+                <div class="list-pane">
+                  <div class="pane-header">
+                    <div class="pane-title">
+                      <div class="pane-kicker">Mailbox</div>
+                      <h2>${this._selectedTab === "inbox" ? "Inbox" : "Outbox"}</h2>
+                    </div>
+                    <div class="tabs">
+                      <button class="tab ${this._selectedTab === "inbox" ? "active" : ""}" data-tab="inbox">Inbox</button>
+                      <button class="tab ${this._selectedTab === "outbox" ? "active" : ""}" data-tab="outbox">Outbox</button>
+                    </div>
+                  </div>
+                  <div class="list-body">
+                    ${loading ? `<div class="loading">Loading messages…</div>` : ""}
+                    <div class="messages">${this._renderMessageList()}</div>
+                  </div>
+                </div>
+                <div class="detail-pane">
+                  <div class="pane-header">
+                    <div class="pane-title">
+                      <div class="pane-kicker">Reader</div>
+                      <h2>${selectedMessage ? "Message details" : "Select a message"}</h2>
+                    </div>
+                    ${selectedMessage ? `<span class="subtle">${this._selectedTab === "inbox" ? "Inbox" : "Outbox"}</span>` : ""}
+                  </div>
+                  ${this._renderMessageDetail()}
+                </div>
+              </section>
+            `
+        }
+
+        <section class="composer">
+          <div class="pane-header">
+            <div class="pane-title">
+              <div class="eyebrow">Compose</div>
+              <h2>Send SMS from Home Assistant</h2>
+            </div>
+            <div class="subtle">Use Reply on a selected message to prefill the recipient.</div>
+          </div>
+          <div class="composer-grid">
+            <label class="phone-field">
+              <div class="field-label">Phone number</div>
+              <div class="control-shell">
+                <input id="compose-phone" type="text" value="${this._escapeHtml(this._composePhone)}" placeholder="+441234567890" />
+              </div>
+            </label>
+            <label class="message-field">
+              <div class="field-label">Message</div>
+              <div class="control-shell multiline">
+                <textarea id="compose-message" placeholder="Write the SMS message here.">${this._escapeHtml(this._composeMessage)}</textarea>
+              </div>
+            </label>
+          </div>
+          <div class="composer-actions">
+            <div class="subtle">Admins only. The router sends this message immediately through its modem.</div>
+            <button id="send-button" class="primary" ${this._sendPending || !this._entries.length ? "disabled" : ""}>
+              ${this._sendPending ? "Sending…" : "Send SMS"}
+            </button>
+          </div>
+        </section>
+      </div>
+    `;
+
+    this.shadowRoot.querySelector("#refresh-button")?.addEventListener("click", () => {
+      this._loadEntries();
+    });
+
+    this.shadowRoot.querySelector("#entry-select")?.addEventListener("change", (event) => {
+      this._selectedEntryId = event.target.value;
+      this._selectedMessageKey = "";
+      this._loadMessages();
+    });
+
+    this.shadowRoot.querySelectorAll("[data-tab]").forEach((button) => {
+      button.addEventListener("click", () => this._setSelectedTab(button.dataset.tab));
+    });
+
+    this.shadowRoot.querySelectorAll("[data-message-key]").forEach((button) => {
+      button.addEventListener("click", () => {
+        this._selectedMessageKey = button.dataset.messageKey || "";
+        this._render();
+      });
+    });
+
+    this.shadowRoot.querySelector("#reply-button")?.addEventListener("click", () => {
+      this._replyToSelectedMessage();
+    });
+
+    this.shadowRoot.querySelector("#compose-phone")?.addEventListener("input", (event) => {
+      this._composePhone = event.target.value;
+    });
+
+    this.shadowRoot.querySelector("#compose-message")?.addEventListener("input", (event) => {
+      this._composeMessage = event.target.value;
+    });
+
+    this.shadowRoot.querySelector("#send-button")?.addEventListener("click", () => {
+      this._sendSms();
+    });
+  }
+}
+
+customElements.define("cudy-router-sms-panel", CudyRouterSmsPanel);

--- a/custom_components/cudy_router/parser.py
+++ b/custom_components/cudy_router/parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import urllib.parse
 from datetime import datetime
 from typing import Any, Tuple
 
@@ -19,6 +20,7 @@ _UP_RE = re.compile(r"up[:\s]+([\d.]+)\s*([kmg]?bps)", re.IGNORECASE)
 _DOWN_RE = re.compile(r"down[:\s]+([\d.]+)\s*([kmg]?bps)", re.IGNORECASE)
 _MAC_RE = re.compile(r"(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}", re.IGNORECASE)
 _IP_RE = re.compile(r"(?:\d{1,3}\.){3}\d{1,3}")
+_SMS_MODAL_HEADER_RE = re.compile(r"^(From|To):\s*(.*?)\s*\(([^()]*)\)\s*$")
 
 
 def _clean_cell_strings(element: Any) -> list[str]:
@@ -614,6 +616,141 @@ def parse_data_usage(input_html: str) -> dict[str, Any]:
     }
 
 
+def _looks_like_login_page(input_html: str) -> bool:
+    """Return whether the HTML looks like the LuCI login form."""
+    if not input_html:
+        return False
+
+    soup = BeautifulSoup(input_html, "html.parser")
+    form = soup.find("form")
+    if form is None:
+        return False
+
+    return (
+        form.find("input", attrs={"name": "luci_password"}) is not None
+        and form.find("input", attrs={"id": "luci_password2"}) is not None
+    )
+
+
+def _find_sms_row_value(row: Any, suffix: str) -> str | None:
+    """Read a deduplicated text value from a table-row div suffix."""
+    element = row.find("div", attrs={"id": re.compile(rf"-{re.escape(suffix)}$")})
+    if element is None:
+        return None
+
+    values = _clean_cell_strings(element)
+    if not values:
+        return None
+    return " ".join(values)
+
+
+def _find_sms_cfg(row: Any) -> str | None:
+    """Extract the LuCI cfg identifier from a message row."""
+    for button in row.find_all("button"):
+        onclick = button.get("onclick", "")
+        if "readsms" not in onclick.lower():
+            continue
+
+        match = re.search(r"cfg=([^&\"']+)", onclick)
+        if match:
+            return urllib.parse.unquote(match.group(1))
+
+    return None
+
+
+def _find_sms_read_state(row: Any) -> bool | None:
+    """Extract the read/unread state from an inbox row."""
+    icon = row.find("i", attrs={"class": re.compile(r"icon-(?:unread|read)sms")})
+    if icon is None:
+        return None
+
+    icon_classes = set(icon.get("class", []))
+    if "icon-unreadsms" in icon_classes:
+        return False
+    if "icon-readsms" in icon_classes:
+        return True
+    return None
+
+
+def parse_sms_list(input_html: str, smsbox: str) -> list[dict[str, Any]] | None:
+    """Parse the SMS inbox or outbox list page."""
+    if not input_html or _looks_like_login_page(input_html):
+        return None
+
+    soup = BeautifulSoup(input_html, "html.parser")
+    if soup.find("table") is None:
+        return None
+
+    folder = "inbox" if smsbox == "rec" else "outbox"
+    direction = "From" if smsbox == "rec" else "To"
+    messages: list[dict[str, Any]] = []
+
+    for row in soup.select("tbody tr[id^='cbi-table-']"):
+        index = as_int(_find_sms_row_value(row, "idx"))
+        phone = _find_sms_row_value(row, "phone")
+        preview = _find_sms_row_value(row, "content")
+        timestamp = _find_sms_row_value(row, "timestamp")
+        cfg = _find_sms_cfg(row)
+        read = _find_sms_read_state(row) if smsbox == "rec" else None
+
+        if not any(value not in (None, "") for value in (phone, preview, timestamp, cfg, index)):
+            continue
+
+        messages.append(
+            {
+                "folder": folder,
+                "direction": direction,
+                "index": index,
+                "phone": phone,
+                "preview": preview,
+                "timestamp": timestamp,
+                "cfg": cfg,
+                "read": read,
+            }
+        )
+
+    return messages
+
+
+def parse_sms_detail(input_html: str) -> dict[str, Any] | None:
+    """Parse an SMS detail modal and extract the full message text."""
+    if not input_html or _looks_like_login_page(input_html):
+        return None
+
+    soup = BeautifulSoup(input_html, "html.parser")
+    header = soup.find("h4", class_="modal-title")
+    text_area = soup.find("textarea", attrs={"name": re.compile(r"\.text$")})
+    phone_input = soup.find("input", attrs={"name": re.compile(r"\.phone$")})
+
+    if header is None and text_area is None and phone_input is None:
+        return None
+
+    header_text = " ".join(header.stripped_strings) if header else ""
+    direction = None
+    phone = phone_input.get("value", "").strip() if phone_input else None
+    timestamp = None
+
+    header_match = _SMS_MODAL_HEADER_RE.match(header_text)
+    if header_match:
+        direction = header_match.group(1)
+        phone = header_match.group(2).strip() or phone
+        timestamp = header_match.group(3).strip() or None
+
+    text = None
+    if text_area is not None:
+        text = text_area.get_text("\n", strip=False).strip() or None
+
+    if not any(value not in (None, "") for value in (direction, phone, timestamp, text)):
+        return None
+
+    return {
+        "direction": direction,
+        "phone": phone,
+        "timestamp": timestamp,
+        "text": text,
+    }
+
+
 def parse_sms_status(input_html: str) -> dict[str, Any]:
     """Parses SMS status page."""
     raw_data = parse_tables(input_html)
@@ -621,7 +758,7 @@ def parse_sms_status(input_html: str) -> dict[str, Any]:
     # Parse new message count from header (look for "New Message" with number)
     new_messages = 0
     soup = BeautifulSoup(input_html, "html.parser")
-    header = soup.find("th", class_="text-primary")
+    header = soup.find("th", class_=re.compile(r"text-(?:primary|success)"))
     if header:
         next_th = header.find_next_sibling("th")
         if next_th:

--- a/custom_components/cudy_router/router_data.py
+++ b/custom_components/cudy_router/router_data.py
@@ -59,7 +59,6 @@ _LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
-
 async def collect_router_data(
     router: Any,
     hass: HomeAssistant,

--- a/custom_components/cudy_router/sensor.py
+++ b/custom_components/cudy_router/sensor.py
@@ -143,6 +143,7 @@ async def async_setup_entry(
     wan_data = coordinator.data.get(MODULE_WAN, {}) if coordinator.data else {}
     for sensor_key in _WAN_REMOVED_SENSOR_KEYS:
         _remove_sensor_by_unique_id(f"{config_entry.entry_id}-{MODULE_WAN}-{sensor_key}")
+    _remove_sensor_by_unique_id(f"{config_entry.entry_id}-sms-messages")
     for sensor_key in _WAN_DUPLICATE_MODEM_KEYS:
         if coordinator.data and MODULE_MODEM in coordinator.data:
             _remove_sensor_by_unique_id(f"{config_entry.entry_id}-{MODULE_WAN}-{sensor_key}")

--- a/custom_components/cudy_router/sms.py
+++ b/custom_components/cudy_router/sms.py
@@ -1,0 +1,186 @@
+"""On-demand SMS helpers for the Cudy Router integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .const import DOMAIN, MODULE_SMS, OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR
+from .features import existing_feature
+from .parser import parse_sms_detail, parse_sms_list, parse_sms_status
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+SMS_STATUS_PATH = "admin/network/gcom/sms/status"
+SMS_PANEL_URL_PATH = "cudy-router-sms"
+SMS_PANEL_COMPONENT_NAME = "cudy-router-sms-panel"
+SMS_PANEL_STATIC_URL = "/cudy_router_static/cudy-router-sms-panel.js"
+SMS_PANEL_STATIC_FILE = "frontend/cudy-router-sms-panel.js"
+
+_SMSBOX_TO_FOLDER = {
+    "rec": "inbox",
+    "sto": "outbox",
+}
+
+
+def _sms_list_path(smsbox: str) -> str:
+    """Return the LuCI path for an inbox or outbox listing."""
+    return f"admin/network/gcom/sms/smslist?smsbox={smsbox}&iface=4g"
+
+
+def _sms_detail_path(cfg: str, smsbox: str) -> str:
+    """Return the LuCI path for an SMS detail modal."""
+    return f"admin/network/gcom/sms/readsms?iface=4g&cfg={cfg}&smsbox={smsbox}"
+
+
+def coordinator_supports_sms(coordinator: Any) -> bool:
+    """Return whether the coordinator's model supports SMS."""
+    model = coordinator.config_entry.data.get("model", "default")
+    return existing_feature(model, MODULE_SMS) is True
+
+
+def coordinator_shows_sms_panel_in_sidebar(coordinator: Any) -> bool:
+    """Return whether the entry wants the SMS panel link in the sidebar."""
+    if not coordinator_supports_sms(coordinator):
+        return False
+    return coordinator.config_entry.options.get(OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR, True)
+
+
+def sms_capable_coordinators(hass: HomeAssistant) -> list[Any]:
+    """Return loaded coordinators that support SMS."""
+    coordinators = hass.data.get(DOMAIN, {})
+    return [
+        coordinator
+        for coordinator in coordinators.values()
+        if hasattr(coordinator, "config_entry") and coordinator_supports_sms(coordinator)
+    ]
+
+
+def sms_summary_from_data(data: dict[str, Any] | None) -> dict[str, int]:
+    """Extract SMS summary counts from coordinator data."""
+    sms_data = (data or {}).get(MODULE_SMS, {})
+    return {
+        "inbox": int(sms_data.get("inbox_count", {}).get("value") or 0),
+        "outbox": int(sms_data.get("outbox_count", {}).get("value") or 0),
+        "unread": int(sms_data.get("unread_count", {}).get("value") or 0),
+    }
+
+
+def sms_entry_payload(coordinator: Any) -> dict[str, Any]:
+    """Return a frontend-friendly description of an SMS-capable entry."""
+    config_entry = coordinator.config_entry
+    return {
+        "entry_id": config_entry.entry_id,
+        "title": config_entry.title or config_entry.data.get("host") or config_entry.entry_id,
+        "host": config_entry.data.get("host"),
+        "model": config_entry.data.get("model", "default"),
+        "counts": sms_summary_from_data(getattr(coordinator, "data", None)),
+    }
+
+
+async def _async_fetch_sms_mailbox(
+    router: Any,
+    hass: HomeAssistant,
+    smsbox: str,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Fetch and enrich one SMS mailbox."""
+    list_html = await hass.async_add_executor_job(router.get, _sms_list_path(smsbox), True)
+    messages = parse_sms_list(list_html, smsbox)
+    if messages is None:
+        return [], False
+
+    detailed_messages: list[dict[str, Any]] = []
+    for message in messages:
+        cfg = message.get("cfg")
+        if not cfg:
+            return [], False
+
+        detail_html = await hass.async_add_executor_job(router.get, _sms_detail_path(cfg, smsbox), True)
+        detail = parse_sms_detail(detail_html)
+        if detail is None:
+            return [], False
+
+        enriched_message = dict(message)
+        enriched_message.update(
+            {
+                key: value
+                for key, value in detail.items()
+                if value not in (None, "")
+            }
+        )
+        detailed_messages.append(enriched_message)
+
+    return detailed_messages, True
+
+
+async def async_fetch_sms_data(
+    hass: HomeAssistant,
+    coordinator: Any,
+) -> dict[str, Any]:
+    """Fetch the latest SMS counts and message bodies for one coordinator."""
+    router = coordinator.api
+    status_html = await hass.async_add_executor_job(router.get, SMS_STATUS_PATH)
+    summary = parse_sms_status(status_html)
+    inbox_messages, inbox_available = await _async_fetch_sms_mailbox(router, hass, "rec")
+    outbox_messages, outbox_available = await _async_fetch_sms_mailbox(router, hass, "sto")
+
+    return {
+        "entry": sms_entry_payload(coordinator),
+        "counts": {
+            "inbox": int(summary.get("inbox_count", {}).get("value") or 0),
+            "outbox": int(summary.get("outbox_count", {}).get("value") or 0),
+            "unread": int(summary.get("unread_count", {}).get("value") or 0),
+        },
+        "mailboxes": {
+            _SMSBOX_TO_FOLDER["rec"]: {
+                "available": inbox_available,
+                "messages": inbox_messages,
+            },
+            _SMSBOX_TO_FOLDER["sto"]: {
+                "available": outbox_available,
+                "messages": outbox_messages,
+            },
+        },
+    }
+
+
+def interpret_send_sms_result(status_code: int, response_text: str) -> dict[str, Any]:
+    """Normalize the router's send-SMS response."""
+    snippet = (response_text or "").strip()
+    normalized = snippet.lower()
+    success = (
+        200 <= status_code < 400
+        and "error" not in normalized
+        and "failed" not in normalized
+    )
+
+    message = snippet or (
+        "SMS sent."
+        if success
+        else "The router did not confirm the SMS send request."
+    )
+
+    return {
+        "success": success,
+        "status_code": status_code,
+        "message": message,
+    }
+
+
+async def async_send_sms_message(
+    hass: HomeAssistant,
+    coordinator: Any,
+    phone_number: str,
+    message: str,
+) -> dict[str, Any]:
+    """Send an SMS and refresh the coordinator if the router accepts it."""
+    status_code, response_text = await hass.async_add_executor_job(
+        coordinator.api.send_sms,
+        phone_number,
+        message,
+    )
+    result = interpret_send_sms_result(status_code, response_text)
+    if result["success"]:
+        await coordinator.async_request_refresh()
+    return result

--- a/custom_components/cudy_router/strings.json
+++ b/custom_components/cudy_router/strings.json
@@ -41,11 +41,13 @@
         "data": {
           "auto_add_connected_devices": "Automatically add connected devices",
           "auto_add_device_trackers": "Automatically add device trackers for connected devices",
+          "show_sms_panel_in_sidebar": "Show Cudy SMS in sidebar",
           "scan_interval": "Update interval"
         },
         "data_description": {
           "auto_add_connected_devices": "Create client devices and live client entities for every currently connected device. Disabled by default for new integrations. Turn this on to automatically create client devices and live per-client entities, or leave it off to only create them for devices listed below.",
           "auto_add_device_trackers": "Create device_tracker entities for every currently connected device with a MAC address. Disabled by default. Turn this on if you want presence-style trackers in addition to the live client entities.",
+          "show_sms_panel_in_sidebar": "Show the Cudy SMS panel link in the Home Assistant sidebar. Disable this to keep the SMS page available only by direct URL.",
           "scan_interval": "How often to poll the router for updates (in seconds)"
         }
       },

--- a/custom_components/cudy_router/translations/en.json
+++ b/custom_components/cudy_router/translations/en.json
@@ -38,11 +38,13 @@
           "data": {
             "auto_add_connected_devices": "Automatically add connected devices",
             "auto_add_device_trackers": "Automatically add device trackers for connected devices",
+            "show_sms_panel_in_sidebar": "Show Cudy SMS in sidebar",
             "scan_interval": "Update interval"
           },
           "data_description": {
             "auto_add_connected_devices": "Create client devices and live client entities for every currently connected device. Disabled by default for new integrations. Turn this on to automatically create client devices and live per-client entities, or leave it off to only create them for devices listed below.",
             "auto_add_device_trackers": "Create device_tracker entities for every currently connected device with a MAC address. Disabled by default. Turn this on if you want presence-style trackers in addition to the live client entities.",
+            "show_sms_panel_in_sidebar": "Show the Cudy SMS panel link in the Home Assistant sidebar. Disable this to keep the SMS page available only by direct URL.",
             "scan_interval": "How often to poll the router for updates (in seconds)"
           },
           "title": "Configure Cudy Router"

--- a/tests/fixtures/sms/inbox_detail.html
+++ b/tests/fixtures/sms/inbox_detail.html
@@ -1,0 +1,20 @@
+<form class="form-horizontal" role="form" method="post" name="cbi" action="/cgi-bin/luci/admin/network/gcom/sms/readsms?iface=4g&amp;cfg=cfginbox1&amp;smsbox=rec">
+  <div>
+    <input type="hidden" name="token" value="fixture-token" />
+    <input type="hidden" name="timeclock" value="" />
+    <input type="hidden" name="cbi.submit" value="1" />
+  </div>
+  <div class="modal-header">
+    <h4 class="modal-title" id="modal-label-smsread">From: +441234500001 (04/12/26, 08:41:23)</h4>
+  </div>
+  <div class="modal-body">
+    <input type="input" class="sr-only hidden" name="cbid.smsread.1.phone" id="cbid.smsread.1.phone" value="+441234500001" />
+    <div class="form-group" id="cbi-smsread-1-text">
+      <label class="col-sm-12" for="cbid.smsread.1.text">Text</label>
+      <div class="col-sm-12">
+        <textarea class="form-control required" name="cbid.smsread.1.text" id="cbid.smsread.1.text" rows="10" readonly="true">Reminder: use *new* code [ALPHA].
+Bring ID.</textarea>
+      </div>
+    </div>
+  </div>
+</form>

--- a/tests/fixtures/sms/inbox_list.html
+++ b/tests/fixtures/sms/inbox_list.html
@@ -1,0 +1,76 @@
+<form class="form-horizontal" role="form" method="post" name="cbi" action="/cgi-bin/luci/admin/network/gcom/sms/smslist?smsbox=rec&amp;iface=4g">
+  <div>
+    <input type="hidden" name="token" value="fixture-token" />
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>No.</th>
+          <th>Status</th>
+          <th>Phone Number</th>
+          <th class="hidden-xs">Content</th>
+          <th class="hidden-xs">Received</th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="cbi-section-table-descr"></tr>
+        <tr id="cbi-table-1" data-sid="1">
+          <td>
+            <div id="cbi-table-1-idx">
+              <p class="form-control-static hidden-xs">1</p>
+              <p class="visible-xs">1</p>
+            </div>
+          </td>
+          <td>
+            <div id="cbi-table-1-icon">
+              <span class="fa-2x"><i class="icon icon-unreadsms text-primary" aria-hidden="true"></i></span>
+            </div>
+          </td>
+          <td>
+            <div id="cbi-table-1-phone">
+              <p class="form-control-static hidden-xs">+441234500001</p>
+              <p class="visible-xs">+441234500001</p>
+            </div>
+          </td>
+          <td class="hidden-xs">
+            <div id="cbi-table-1-content">
+              <p class="form-control-static hidden-xs">Reminder: use *new* code [ALPHA]...</p>
+              <p class="visible-xs">Reminder: use *new* code [ALPHA]...</p>
+            </div>
+          </td>
+          <td class="hidden-xs">
+            <div id="cbi-table-1-timestamp">
+              <p class="form-control-static hidden-xs">04/12/26, 08:41:23</p>
+              <p class="visible-xs">04/12/26, 08:41:23</p>
+            </div>
+          </td>
+          <td>
+            <div id="cbi-table-1-readsms">
+              <button
+                class="btn btn-primary"
+                type="submit"
+                onclick='cbi_show_modal(this, "/cgi-bin/luci/admin/network/gcom/sms/readsms", "iface=4g&amp;cfg=cfginbox1&amp;smsbox=rec");return false;'
+                name="cbid.table.1.readsms"
+                value="More Details"
+              >More Details</button>
+            </div>
+          </td>
+          <td>
+            <div id="cbi-table-1-delsms">
+              <button
+                class="btn btn-danger"
+                type="submit"
+                onclick='cbi_show_modal(this, "/cgi-bin/luci/admin/network/gcom/sms/delsms", "iface=4g&amp;cfg=cfginbox1");return false;'
+                name="cbid.table.1.delsms"
+                value="Delete"
+              >Delete</button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</form>

--- a/tests/fixtures/sms/outbox_detail.html
+++ b/tests/fixtures/sms/outbox_detail.html
@@ -1,0 +1,19 @@
+<form class="form-horizontal" role="form" method="post" name="cbi" action="/cgi-bin/luci/admin/network/gcom/sms/readsms?iface=4g&amp;cfg=cfgoutbox1&amp;smsbox=sto">
+  <div>
+    <input type="hidden" name="token" value="fixture-token" />
+    <input type="hidden" name="timeclock" value="" />
+    <input type="hidden" name="cbi.submit" value="1" />
+  </div>
+  <div class="modal-header">
+    <h4 class="modal-title" id="modal-label-smsread">To: +441234500002 (04/12/26, 08:55:00)</h4>
+  </div>
+  <div class="modal-body">
+    <input type="input" class="sr-only hidden" name="cbid.smsread.1.phone" id="cbid.smsread.1.phone" value="+441234500002" />
+    <div class="form-group" id="cbi-smsread-1-text">
+      <label class="col-sm-12" for="cbid.smsread.1.text">Text</label>
+      <div class="col-sm-12">
+        <textarea class="form-control required" name="cbid.smsread.1.text" id="cbid.smsread.1.text" rows="10" readonly="true">Confirmed | back gate at 18:00.</textarea>
+      </div>
+    </div>
+  </div>
+</form>

--- a/tests/fixtures/sms/outbox_list.html
+++ b/tests/fixtures/sms/outbox_list.html
@@ -1,0 +1,70 @@
+<form class="form-horizontal" role="form" method="post" name="cbi" action="/cgi-bin/luci/admin/network/gcom/sms/smslist?smsbox=sto&amp;iface=4g">
+  <div>
+    <input type="hidden" name="token" value="fixture-token" />
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>No.</th>
+          <th>Phone Number</th>
+          <th class="hidden-xs">Content</th>
+          <th class="hidden-xs">Sent</th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="cbi-section-table-descr"></tr>
+        <tr id="cbi-table-1" data-sid="1">
+          <td>
+            <div id="cbi-table-1-idx">
+              <p class="form-control-static hidden-xs">1</p>
+              <p class="visible-xs">1</p>
+            </div>
+          </td>
+          <td>
+            <div id="cbi-table-1-phone">
+              <p class="form-control-static hidden-xs">+441234500002</p>
+              <p class="visible-xs">+441234500002</p>
+            </div>
+          </td>
+          <td class="hidden-xs">
+            <div id="cbi-table-1-content">
+              <p class="form-control-static hidden-xs">Confirmed | back gate...</p>
+              <p class="visible-xs">Confirmed | back gate...</p>
+            </div>
+          </td>
+          <td class="hidden-xs">
+            <div id="cbi-table-1-timestamp">
+              <p class="form-control-static hidden-xs">04/12/26, 08:55:00</p>
+              <p class="visible-xs">04/12/26, 08:55:00</p>
+            </div>
+          </td>
+          <td>
+            <div id="cbi-table-1-readsms">
+              <button
+                class="btn btn-primary"
+                type="submit"
+                onclick='cbi_show_modal(this, "/cgi-bin/luci/admin/network/gcom/sms/readsms", "iface=4g&amp;cfg=cfgoutbox1&amp;smsbox=sto");return false;'
+                name="cbid.table.1.readsms"
+                value="More Details"
+              >More Details</button>
+            </div>
+          </td>
+          <td>
+            <div id="cbi-table-1-delsms">
+              <button
+                class="btn btn-danger"
+                type="submit"
+                onclick='cbi_show_modal(this, "/cgi-bin/luci/admin/network/gcom/sms/delsms", "iface=4g&amp;cfg=cfgoutbox1");return false;'
+                name="cbid.table.1.delsms"
+                value="Delete"
+              >Delete</button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</form>

--- a/tests/fixtures/sms/status.html
+++ b/tests/fixtures/sms/status.html
@@ -1,0 +1,29 @@
+<div class="panel panel-primary">
+  <div class="panel-heading">
+    <h3 class="panel-title"><i class="icon icon-sms"></i>&nbsp;&nbsp;SMS</h3>
+  </div>
+  <div class="table-responsive">
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="text-success">New Message</th>
+          <th class="text-success">1</th>
+          <th><i class="fa fa-check text-success" aria-hidden="true"></i></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="cbi-section-table-descr"></tr>
+        <tr id="cbi-table-1">
+          <td><p class="visible-xs">Inbox</p></td>
+          <td><p class="visible-xs">1</p></td>
+          <td><i class="fa fa-inbox text-primary" aria-hidden="true"></i></td>
+        </tr>
+        <tr id="cbi-table-2">
+          <td><p class="visible-xs">Outbox</p></td>
+          <td><p class="visible-xs">1</p></td>
+          <td><i class="fa fa-paper-plane text-primary" aria-hidden="true"></i></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/tests/test_parser_multi_model.py
+++ b/tests/test_parser_multi_model.py
@@ -58,6 +58,55 @@ def test_parse_system_status_supports_alternate_labels() -> None:
     assert parsed["uptime"]["value"] == pytest.approx(97276.0)
 
 
+def test_parse_sms_status_and_inbox_rows_from_p5_layout() -> None:
+    """SMS parsing should extract counts and inbox row metadata from the P5 layout."""
+    status = parser.parse_sms_status(_fixture_text("sms", "status.html"))
+    inbox_messages = parser.parse_sms_list(_fixture_text("sms", "inbox_list.html"), "rec")
+
+    assert status["inbox_count"]["value"] == 1
+    assert status["outbox_count"]["value"] == 1
+    assert status["unread_count"]["value"] == 1
+    assert inbox_messages is not None
+    assert len(inbox_messages) == 1
+    assert inbox_messages[0]["folder"] == "inbox"
+    assert inbox_messages[0]["index"] == 1
+    assert inbox_messages[0]["phone"] == "+441234500001"
+    assert inbox_messages[0]["timestamp"] == "04/12/26, 08:41:23"
+    assert inbox_messages[0]["cfg"] == "cfginbox1"
+    assert inbox_messages[0]["read"] is False
+
+
+def test_parse_sms_outbox_rows_and_detail_modal() -> None:
+    """SMS parsing should extract outbox metadata and full detail text."""
+    outbox_messages = parser.parse_sms_list(_fixture_text("sms", "outbox_list.html"), "sto")
+    outbox_detail = parser.parse_sms_detail(_fixture_text("sms", "outbox_detail.html"))
+
+    assert outbox_messages is not None
+    assert len(outbox_messages) == 1
+    assert outbox_messages[0]["folder"] == "outbox"
+    assert outbox_messages[0]["preview"] == "Confirmed | back gate..."
+    assert outbox_messages[0]["cfg"] == "cfgoutbox1"
+    assert outbox_messages[0]["read"] is None
+    assert outbox_detail == {
+        "direction": "To",
+        "phone": "+441234500002",
+        "timestamp": "04/12/26, 08:55:00",
+        "text": "Confirmed | back gate at 18:00.",
+    }
+
+
+def test_parse_sms_inbox_detail_modal() -> None:
+    """SMS detail parsing should preserve the full inbox message body."""
+    inbox_detail = parser.parse_sms_detail(_fixture_text("sms", "inbox_detail.html"))
+
+    assert inbox_detail == {
+        "direction": "From",
+        "phone": "+441234500001",
+        "timestamp": "04/12/26, 08:41:23",
+        "text": "Reminder: use *new* code [ALPHA].\nBring ID.",
+    }
+
+
 def test_parse_wan_status_supports_alternate_labels() -> None:
     """WAN parser should accept common alternate field names."""
     parsed = parser_network.parse_wan_status(_fixture_text("wan", "wan_alt_labels.html"))

--- a/tests/test_readme_feature_docs.py
+++ b/tests/test_readme_feature_docs.py
@@ -31,6 +31,10 @@ def test_readme_documents_new_settings_entities() -> None:
     assert "VPN switch" in source
     assert "WiFi 2.4G hidden network" in source
     assert "WiFi 5G separate clients" in source
+    assert "Cudy SMS" in source
+    assert "/cudy-router-sms" in source
+    assert "Show Cudy SMS in sidebar" in source
+    assert "device page still keeps `SMS inbox`, `SMS outbox`, and `SMS unread`" in source
 
 
 def test_readme_documents_connected_device_auto_add_option() -> None:

--- a/tests/test_router_data_collection.py
+++ b/tests/test_router_data_collection.py
@@ -26,9 +26,10 @@ class _FakeHass:
 class _FakeRouter:
     def __init__(self, pages: dict[str, str]) -> None:
         self._pages = pages
+        self.requests: list[tuple[str, bool]] = []
 
     def get(self, path: str, silent: bool = False) -> str:
-        del silent
+        self.requests.append((path, silent))
         return self._pages.get(path, "")
 
 
@@ -234,3 +235,97 @@ def test_collect_router_data_falls_back_to_alternate_r700_subnet_config_paths(mo
 
     assert data[const.MODULE_LAN]["subnet_mask"]["value"] == "255.255.255.0"
     assert data[const.MODULE_WAN]["subnet_mask"]["value"] == "255.255.255.0"
+
+
+def test_collect_router_data_keeps_sms_counts_summary_only(monkeypatch) -> None:
+    """SMS-capable routers should keep summary counts in coordinator data only."""
+    monkeypatch.setattr(
+        router_data,
+        "existing_feature",
+        lambda device_model, module: module == const.MODULE_SMS,
+    )
+    fake_router = _FakeRouter(
+        {
+            "admin/network/gcom/sms/status": _fixture_text("sms", "status.html"),
+            "admin/network/gcom/sms/smslist?smsbox=rec&iface=4g": _fixture_text("sms", "inbox_list.html"),
+            "admin/network/gcom/sms/smslist?smsbox=sto&iface=4g": _fixture_text("sms", "outbox_list.html"),
+            "admin/network/gcom/sms/readsms?iface=4g&cfg=cfginbox1&smsbox=rec": _fixture_text(
+                "sms",
+                "inbox_detail.html",
+            ),
+            "admin/network/gcom/sms/readsms?iface=4g&cfg=cfgoutbox1&smsbox=sto": _fixture_text(
+                "sms",
+                "outbox_detail.html",
+            ),
+        }
+    )
+
+    data = asyncio.run(
+        router_data.collect_router_data(
+            fake_router,
+            _FakeHass(),
+            {},
+            "P5",
+        )
+    )
+
+    assert data[const.MODULE_SMS]["inbox_count"]["value"] == 1
+    assert data[const.MODULE_SMS]["outbox_count"]["value"] == 1
+    assert data[const.MODULE_SMS]["unread_count"]["value"] == 1
+    assert "messages" not in data[const.MODULE_SMS]
+    assert fake_router.requests == [("admin/network/gcom/sms/status", False)]
+
+
+def test_collect_router_data_does_not_fetch_detailed_sms_pages(monkeypatch) -> None:
+    """Coordinator polling should no longer fetch SMS inbox or outbox details."""
+    monkeypatch.setattr(
+        router_data,
+        "existing_feature",
+        lambda device_model, module: module == const.MODULE_SMS,
+    )
+    fake_router = _FakeRouter(
+        {
+            "admin/network/gcom/sms/status": _fixture_text("sms", "status.html"),
+            "admin/network/gcom/sms/smslist?smsbox=rec&iface=4g": "",
+            "admin/network/gcom/sms/smslist?smsbox=sto&iface=4g": "",
+        }
+    )
+
+    data = asyncio.run(
+        router_data.collect_router_data(
+            fake_router,
+            _FakeHass(),
+            {},
+            "P5",
+        )
+    )
+
+    assert data[const.MODULE_SMS]["inbox_count"]["value"] == 1
+    assert data[const.MODULE_SMS]["outbox_count"]["value"] == 1
+    assert "messages" not in data[const.MODULE_SMS]
+    assert all("/smslist?" not in path and "/readsms?" not in path for path, _ in fake_router.requests)
+
+
+def test_collect_router_data_skips_sms_module_for_non_sms_models(monkeypatch) -> None:
+    """Routers without SMS support should not attempt to build SMS sensors."""
+    monkeypatch.setattr(
+        router_data,
+        "existing_feature",
+        lambda device_model, module: False,
+    )
+    fake_router = _FakeRouter(
+        {
+            "admin/network/gcom/sms/status": _fixture_text("sms", "status.html"),
+        }
+    )
+
+    data = asyncio.run(
+        router_data.collect_router_data(
+            fake_router,
+            _FakeHass(),
+            {},
+            "WR6500 V1.0",
+        )
+    )
+
+    assert const.MODULE_SMS not in data

--- a/tests/test_sms_frontend_wiring.py
+++ b/tests/test_sms_frontend_wiring.py
@@ -1,0 +1,93 @@
+"""Static wiring checks for the SMS panel implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_PATH = ROOT / "custom_components" / "cudy_router" / "frontend.py"
+PANEL_JS_PATH = ROOT / "custom_components" / "cudy_router" / "frontend" / "cudy-router-sms-panel.js"
+INIT_PATH = ROOT / "custom_components" / "cudy_router" / "__init__.py"
+SENSOR_PATH = ROOT / "custom_components" / "cudy_router" / "sensor.py"
+SENSOR_DESCRIPTIONS_PATH = ROOT / "custom_components" / "cudy_router" / "sensor_descriptions.py"
+CONFIG_FLOW_PATH = ROOT / "custom_components" / "cudy_router" / "config_flow.py"
+STRINGS_PATH = ROOT / "custom_components" / "cudy_router" / "strings.json"
+TRANSLATIONS_PATH = ROOT / "custom_components" / "cudy_router" / "translations" / "en.json"
+
+
+def test_frontend_module_registers_panel_and_websocket_commands() -> None:
+    """The integration should ship admin-only frontend wiring for SMS."""
+    source = FRONTEND_PATH.read_text(encoding="utf-8")
+
+    assert "async_register_built_in_panel" in source
+    assert "async_remove_panel" in source
+    assert "StaticPathConfig" in source
+    assert '"cudy_router/sms/list_entries"' in source
+    assert '"cudy_router/sms/get_messages"' in source
+    assert '"cudy_router/sms/send"' in source
+    assert "@websocket_api.require_admin" in source
+    assert 'sidebar_title="Cudy SMS"' in source
+    assert 'frontend_url_path=SMS_PANEL_URL_PATH' in source
+    assert "show_in_sidebar=show_in_sidebar" in source
+    assert "update=runtime[\"panel_registered\"]" in source
+    assert '"embed_iframe": False' in source
+    assert 'panel_path.stat().st_mtime_ns' in source
+    assert '"module_url": f"{SMS_PANEL_STATIC_URL}?v={panel_version}"' in source
+    assert 'f"{SMS_PANEL_STATIC_URL}?v={panel_version}"' in source
+
+
+def test_frontend_panel_bundle_exists_and_supports_compose_flow() -> None:
+    """The shipped panel bundle should include inbox/outbox browsing and compose actions."""
+    source = PANEL_JS_PATH.read_text(encoding="utf-8")
+
+    assert 'customElements.define("cudy-router-sms-panel"' in source
+    assert 'type: "cudy_router/sms/get_messages"' in source
+    assert 'type: "cudy_router/sms/send"' in source
+    assert "Reply" in source
+    assert "Send SMS" in source
+    assert "Inbox" in source
+    assert "Outbox" in source
+    assert "--paper-font-common-base_-_font-family" in source
+    assert "--sms-panel-card-background" in source
+    assert "--sms-panel-border-strong" in source
+    assert "--sms-panel-accent-deep" in source
+    assert "linear-gradient(" in source
+    assert ".primary:disabled" in source
+    assert "text-shadow:" in source
+    assert "pane-header" in source
+    assert "hero-grid" in source
+    assert "composer-actions" in source
+    assert "list-body" in source
+    assert "phone-field" in source
+    assert "--sms-panel-control-outline" in source
+    assert "--sms-panel-control-background" in source
+    assert "0 0 0 1px var(--sms-panel-control-outline)" in source
+    assert "toolbar-button" in source
+    assert "message-item.active" in source
+    assert "appearance: none;" in source
+    assert "min-width: 104px;" in source
+
+
+def test_init_refreshes_frontend_and_sensor_cleans_up_removed_sms_entity() -> None:
+    """Runtime wiring should refresh the panel state and remove the retired sensor entity."""
+    init_source = INIT_PATH.read_text(encoding="utf-8")
+    sensor_source = SENSOR_PATH.read_text(encoding="utf-8")
+    descriptions_source = SENSOR_DESCRIPTIONS_PATH.read_text(encoding="utf-8")
+
+    assert "async_refresh_frontend" in init_source
+    assert '_remove_sensor_by_unique_id(f"{config_entry.entry_id}-sms-messages")' in sensor_source
+    assert "SMS messages" not in descriptions_source
+
+
+def test_sms_sidebar_option_is_declared_only_in_options_resources() -> None:
+    """The SMS sidebar visibility option should be wired into the options flow and translations."""
+    config_flow_source = CONFIG_FLOW_PATH.read_text(encoding="utf-8")
+    strings_source = STRINGS_PATH.read_text(encoding="utf-8")
+    translations_source = TRANSLATIONS_PATH.read_text(encoding="utf-8")
+
+    assert "OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR" in config_flow_source
+    assert "show_sms_panel_in_sidebar" in strings_source
+    assert "Show Cudy SMS in sidebar" in strings_source
+    assert "keep the SMS page available only by direct URL" in strings_source
+    assert "show_sms_panel_in_sidebar" in translations_source

--- a/tests/test_sms_helpers.py
+++ b/tests/test_sms_helpers.py
@@ -1,0 +1,175 @@
+"""Targeted tests for the SMS helper module."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from tests.module_loader import load_cudy_module
+
+
+const = load_cudy_module("const")
+load_cudy_module("model_names")
+sms = load_cudy_module("sms")
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _fixture_text(*parts: str) -> str:
+    return FIXTURES.joinpath(*parts).read_text(encoding="utf-8")
+
+
+class _FakeHass:
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+
+class _FakeRouter:
+    def __init__(self, pages: dict[str, str], send_result: tuple[int, str] = (200, "Sent")) -> None:
+        self._pages = pages
+        self._send_result = send_result
+        self.requests: list[tuple[str, bool]] = []
+
+    def get(self, path: str, silent: bool = False) -> str:
+        self.requests.append((path, silent))
+        return self._pages.get(path, "")
+
+    def send_sms(self, phone_number: str, message: str) -> tuple[int, str]:
+        self.last_send = (phone_number, message)
+        return self._send_result
+
+
+class _FakeConfigEntry:
+    def __init__(self, entry_id: str = "entry-1", title: str = "P5 Router") -> None:
+        self.entry_id = entry_id
+        self.title = title
+        self.data = {
+            "host": "http://192.168.10.1",
+            "model": "P5",
+        }
+        self.options: dict[str, object] = {}
+
+
+class _FakeCoordinator:
+    def __init__(self, router: _FakeRouter) -> None:
+        self.api = router
+        self.config_entry = _FakeConfigEntry()
+        self.data = {
+            const.MODULE_SMS: {
+                "inbox_count": {"value": 1},
+                "outbox_count": {"value": 1},
+                "unread_count": {"value": 1},
+            }
+        }
+        self.refresh_calls = 0
+
+    async def async_request_refresh(self) -> None:
+        self.refresh_calls += 1
+
+
+def test_async_fetch_sms_data_reads_full_mailboxes_on_demand() -> None:
+    """The helper should fetch inbox and outbox bodies only when requested."""
+    router = _FakeRouter(
+        {
+            "admin/network/gcom/sms/status": _fixture_text("sms", "status.html"),
+            "admin/network/gcom/sms/smslist?smsbox=rec&iface=4g": _fixture_text("sms", "inbox_list.html"),
+            "admin/network/gcom/sms/smslist?smsbox=sto&iface=4g": _fixture_text("sms", "outbox_list.html"),
+            "admin/network/gcom/sms/readsms?iface=4g&cfg=cfginbox1&smsbox=rec": _fixture_text(
+                "sms",
+                "inbox_detail.html",
+            ),
+            "admin/network/gcom/sms/readsms?iface=4g&cfg=cfgoutbox1&smsbox=sto": _fixture_text(
+                "sms",
+                "outbox_detail.html",
+            ),
+        }
+    )
+    coordinator = _FakeCoordinator(router)
+
+    result = asyncio.run(sms.async_fetch_sms_data(_FakeHass(), coordinator))
+
+    assert result["counts"] == {"inbox": 1, "outbox": 1, "unread": 1}
+    assert result["mailboxes"]["inbox"]["available"] is True
+    assert result["mailboxes"]["outbox"]["available"] is True
+    assert result["mailboxes"]["inbox"]["messages"][0]["text"] == "Reminder: use *new* code [ALPHA].\nBring ID."
+    assert result["mailboxes"]["outbox"]["messages"][0]["text"] == "Confirmed | back gate at 18:00."
+    assert [path for path, _ in router.requests] == [
+        "admin/network/gcom/sms/status",
+        "admin/network/gcom/sms/smslist?smsbox=rec&iface=4g",
+        "admin/network/gcom/sms/readsms?iface=4g&cfg=cfginbox1&smsbox=rec",
+        "admin/network/gcom/sms/smslist?smsbox=sto&iface=4g",
+        "admin/network/gcom/sms/readsms?iface=4g&cfg=cfgoutbox1&smsbox=sto",
+    ]
+
+
+def test_async_fetch_sms_data_reports_unavailable_mailboxes() -> None:
+    """Blank list pages should surface as unavailable mailboxes, not as entity state."""
+    router = _FakeRouter(
+        {
+            "admin/network/gcom/sms/status": _fixture_text("sms", "status.html"),
+            "admin/network/gcom/sms/smslist?smsbox=rec&iface=4g": "",
+            "admin/network/gcom/sms/smslist?smsbox=sto&iface=4g": "",
+        }
+    )
+    coordinator = _FakeCoordinator(router)
+
+    result = asyncio.run(sms.async_fetch_sms_data(_FakeHass(), coordinator))
+
+    assert result["counts"] == {"inbox": 1, "outbox": 1, "unread": 1}
+    assert result["mailboxes"]["inbox"] == {"available": False, "messages": []}
+    assert result["mailboxes"]["outbox"] == {"available": False, "messages": []}
+
+
+def test_async_send_sms_message_refreshes_on_success() -> None:
+    """Successful sends should refresh the coordinator summary data."""
+    coordinator = _FakeCoordinator(_FakeRouter({}, send_result=(200, "Queued successfully")))
+
+    result = asyncio.run(
+        sms.async_send_sms_message(
+            _FakeHass(),
+            coordinator,
+            "+441234500003",
+            "See you soon",
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "status_code": 200,
+        "message": "Queued successfully",
+    }
+    assert coordinator.refresh_calls == 1
+
+
+def test_async_send_sms_message_returns_failure_without_refresh() -> None:
+    """Failed sends should keep the coordinator untouched and expose the router error."""
+    coordinator = _FakeCoordinator(_FakeRouter({}, send_result=(500, "Send failed")))
+
+    result = asyncio.run(
+        sms.async_send_sms_message(
+            _FakeHass(),
+            coordinator,
+            "+441234500004",
+            "Status update",
+        )
+    )
+
+    assert result == {
+        "success": False,
+        "status_code": 500,
+        "message": "Send failed",
+    }
+    assert coordinator.refresh_calls == 0
+
+
+def test_sidebar_visibility_defaults_to_enabled_for_sms_entries() -> None:
+    """SMS-capable entries should show the panel link unless explicitly disabled."""
+    coordinator = _FakeCoordinator(_FakeRouter({}))
+
+    assert sms.coordinator_shows_sms_panel_in_sidebar(coordinator) is True
+
+    coordinator.config_entry.options = {
+        const.OPTIONS_SHOW_SMS_PANEL_IN_SIDEBAR: False,
+    }
+
+    assert sms.coordinator_shows_sms_panel_in_sidebar(coordinator) is False


### PR DESCRIPTION
Introduce an admin-only Cudy SMS panel for routers that expose the SMS LuCI endpoints. The panel lets Home Assistant users browse inbox and outbox messages, read full message bodies, reply from a selected message, and send new SMS messages from the same screen.

Keep the device page behavior conservative by leaving the existing SMS count sensors in place and removing the temporary Markdown sensor approach. Add an options-flow setting that only appears for SMS-capable routers so the sidebar link can be hidden without removing direct access to the panel.

Support the page with dedicated backend helpers, websocket commands, frontend registration, and parser coverage for SMS list and detail pages. Update the documentation and add focused tests for the new frontend wiring, on-demand SMS fetching, and router-data handling.